### PR TITLE
Handle CR characters in log messages

### DIFF
--- a/teamcity.go
+++ b/teamcity.go
@@ -104,6 +104,7 @@ func (test *TeamCityTest) FormatTestOutput() string {
 
 func escapeOutput(outputLines string) string {
 	newOutput := strings.Replace(outputLines, "|", "||", -1)
+	newOutput = strings.Replace(newOutput, "\r", "|r", -1)
 	newOutput = strings.Replace(newOutput, "\n", "|n", -1)
 	newOutput = strings.Replace(newOutput, "'", "|'", -1)
 	newOutput = strings.Replace(newOutput, "]", "|]", -1)


### PR DESCRIPTION
Adds the escape sequence for CR (`\r`) characters in log messages. Can occur especially when dumping HTTP requests, since HTTP uses `CRLF` in request and response headers

Reference https://www.jetbrains.com/help/teamcity/service-messages.html#Escaped+Values